### PR TITLE
fix(security): upgrade jackson-databind 2.10.2 → 2.13.4.2 (CVE-2022-42003)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -202,7 +202,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.10.2</version>
+            <version>2.13.4.2</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Security Fix: CVE-2022-42003

Upgrades `jackson-databind` from `2.10.2` to `2.13.4.2`.

**CVE:** [CVE-2022-42003](https://nvd.nist.gov/vuln/detail/CVE-2022-42003)
**Severity:** HIGH (CVSS 7.5)
**Impact:** Denial-of-service via deeply nested objects during deserialization — causes `StackOverflowError` on malicious JSON input.

### Change

```xml
- <version>2.10.2</version>
+ <version>2.13.4.2</version>
```

### Detection

Found by [Synthesis](https://github.com/exoreaction/Synthesis) CKG-5 security scanner (signal S010: known dependency vulnerability) during a portfolio-wide scan on 2026-02-22. Fixed with [Claude Code](https://claude.ai/claude-code).

Closes #326